### PR TITLE
feat: prepare backend persistence for recipes, meal planner, and grocery list

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -1,64 +1,42 @@
 import { type ClientSchema, a, defineData } from '@aws-amplify/backend';
 
-/*== STEP 1 ===============================================================
-The section below creates a Todo database table with a "content" field. Try
-adding a new "isDone" field as a boolean. The authorization rule below
-specifies that any unauthenticated user can "create", "read", "update", 
-and "delete" any "Todo" records.
-=========================================================================*/
-// Define your Data schema
-
-
-//NEED TO UPDATE TO FIT OUT APP
+// Keep the first persistence pass close to the current frontend state:
+// recipes, meal-plan slot assignments, and grocery items.
 const schema = a.schema({
-
-  User: a
+  Recipe: a
     .model({
-      id: a.id(),
-      email: a.string().required(),
-      name: a.string().required(),
-      createdAt: a.datetime(),
-    })
-    .authorization((allow) => [
-      allow.owner(),
-      allow.authenticated().to(['read']),
-    ]),
-
-  MealPlan: a
-    .model({
+      id: a.id().required(),
       title: a.string().required(),
-      date: a.date(),
-      userId: a.id().required(),
-    })
-    .authorization((allow) => [
-      allow.owner(),
-    ]),
-
-  Meal: a
-    .model({
-      name: a.string().required(),
-      mealType: a.string().required(),
       image: a.string(),
       servings: a.integer(),
-      prepTime: a.integer(),
-      cookTime: a.integer(),
-      mealPlanId: a.id().required(),
+      preparationMinutes: a.integer(),
+      cookingMinutes: a.integer(),
       nutrition: a.json(),
+      extendedIngredients: a.json(),
+      tags: a.string().array(),
+      source: a.string().required(),
     })
-    .authorization((allow) => [
-      allow.owner(),
-    ]),
+    .authorization((allow) => [allow.owner()]),
 
-  Ingredient: a
+  MealPlanEntry: a
     .model({
-      item: a.string().required(),
-      amount: a.string(),
-      category: a.string(),
-      mealId: a.id().required(),
+      id: a.id().required(),
+      date: a.date().required(),
+      slot: a.string().required(),
+      recipeId: a.id().required(),
     })
-    .authorization((allow) => [
-      allow.owner(),
-    ]),
+    .authorization((allow) => [allow.owner()]),
+
+  GroceryItem: a
+    .model({
+      id: a.id().required(),
+      name: a.string().required(),
+      quantity: a.string(),
+      category: a.string(),
+      source: a.string(),
+      checked: a.boolean().required(),
+    })
+    .authorization((allow) => [allow.owner()]),
 });
 
 export type Schema = ClientSchema<typeof schema>;
@@ -69,33 +47,3 @@ export const data = defineData({
     defaultAuthorizationMode: 'userPool',
   },
 });
-
-
-/*== STEP 2 ===============================================================
-Go to your frontend source code. From your client-side code, generate a
-Data client to make CRUDL requests to your table. (THIS SNIPPET WILL ONLY
-WORK IN THE FRONTEND CODE FILE.)
-
-Using JavaScript or Next.js React Server Components, Middleware, Server 
-Actions or Pages Router? Review how to generate Data clients for those use
-cases: https://docs.amplify.aws/gen2/build-a-backend/data/connect-to-API/
-=========================================================================*/
-
-/*
-"use client"
-import { generateClient } from "aws-amplify/data";
-import type { Schema } from "@/amplify/data/resource";
-
-const client = generateClient<Schema>() // use this Data client for CRUDL requests
-*/
-
-/*== STEP 3 ===============================================================
-Fetch records from the database and use them in your frontend component.
-(THIS SNIPPET WILL ONLY WORK IN THE FRONTEND CODE FILE.)
-=========================================================================*/
-
-/* For example, in a React component, you can use this snippet in your
-  function's RETURN statement */
-// const { data: todos } = await client.models.Todo.list()
-
-// return <ul>{todos.map(todo => <li key={todo.id}>{todo.content}</li>)}</ul>

--- a/client/src/components/AddRecipe.jsx
+++ b/client/src/components/AddRecipe.jsx
@@ -104,7 +104,7 @@ export default function AddRecipe({
         );
     };
 
-    const handleSubmit = (e) => {
+    const handleSubmit = async (e) => {
         e.preventDefault();
 
 
@@ -153,7 +153,12 @@ export default function AddRecipe({
         };
 
 
-        onSave(manualRecipe);
+        try {
+            await onSave(manualRecipe);
+        } catch (error) {
+            alert(error.message || 'Unable to save recipe right now.');
+            return;
+        }
 
 
         // Reset form

--- a/client/src/components/DashboardCalendar.jsx
+++ b/client/src/components/DashboardCalendar.jsx
@@ -2,10 +2,9 @@
 
 import dayjs from 'dayjs';
 import { useMemo } from 'react';
-import { loadMealPlanEntries } from '../features/mealPlanner/mealPlannerRepo';
 
 
-export default function DashboardCalendar({ allRecipes = [] }) {
+export default function DashboardCalendar({ allRecipes = [], mealPlanEntries = [] }) {
     // Get current week (Sun-Sat)
     const currentWeekStart = dayjs().startOf('week');
     const days = useMemo(() =>
@@ -15,10 +14,6 @@ export default function DashboardCalendar({ allRecipes = [] }) {
 
 
     const today = dayjs().format('YYYY-MM-DD');
-
-    // Load all meal plan entries
-    const mealPlanEntries = useMemo(() => loadMealPlanEntries(), []);
-
     // Get meals for a specific day
     const getMealsForDay = (date) => {
         const dayEntries = mealPlanEntries.filter(

--- a/client/src/components/GroceryListWidget.jsx
+++ b/client/src/components/GroceryListWidget.jsx
@@ -2,73 +2,80 @@
 
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { getGroceryItems, getGroceryStorageKey, saveGroceryItems } from '../features/grocery/groceryStorage';
-
+import { getGroceryItems, saveGroceryItems } from '../features/grocery/groceryStorage';
 
 const DEFAULT_VISIBLE_ITEMS = 10;
-
 
 const sortGroceryItems = (items) => {
     return [...items].sort((a, b) => Number(a.checked) - Number(b.checked));
 };
 
-
 export default function GroceryListWidget() {
     const navigate = useNavigate();
     const [visibleCount, setVisibleCount] = useState(DEFAULT_VISIBLE_ITEMS);
+    const [items, setItems] = useState([]);
+    const [isLoading, setIsLoading] = useState(true);
 
-
-    // load grocery items from localStorage
-    const [items, setItems] = useState(() => {
-        return sortGroceryItems(getGroceryItems());
-    });
-
-
-    // Reload data when component mounts or becomes visible
     useEffect(() => {
-        const loadItems = () => {
-            setItems(sortGroceryItems(getGroceryItems()));
+        let isMounted = true;
+
+        const loadItems = async () => {
+            try {
+                const loadedItems = await getGroceryItems();
+
+                if (isMounted) {
+                    setItems(sortGroceryItems(loadedItems));
+                }
+            } catch (error) {
+                console.error('Failed to load grocery items:', error);
+            } finally {
+                if (isMounted) {
+                    setIsLoading(false);
+                }
+            }
         };
 
-        // Load immediately
         loadItems();
 
-
-        // Reload when window regains focus (user comes back to tab)
-        const handleFocus = () => loadItems();
+        const handleFocus = () => {
+            loadItems();
+        };
         window.addEventListener('focus', handleFocus);
 
-
-        // Reload when storage changes in another tab
-        const handleStorage = (e) => {
-            if (e.key === getGroceryStorageKey()) loadItems();
-        };
-        window.addEventListener('storage', handleStorage);
-
-
         return () => {
+            isMounted = false;
             window.removeEventListener('focus', handleFocus);
-            window.removeEventListener('storage', handleStorage);
         };
     }, []);
 
-    const toggleCheck = (id) => {
-        const updatedItems = sortGroceryItems(items.map(item =>
+    const persistItems = async (nextItems) => {
+        const previousItems = items;
+        setItems(nextItems);
+
+        try {
+            await saveGroceryItems(nextItems, previousItems);
+        } catch (error) {
+            console.error('Failed to save grocery widget items:', error);
+            setItems(previousItems);
+            alert(error.message || 'We could not update your grocery list right now.');
+        }
+    };
+
+    const toggleCheck = async (id) => {
+        const updatedItems = sortGroceryItems(items.map((item) =>
             item.id === id ? { ...item, checked: !item.checked } : item
         ));
 
-        setItems(updatedItems);
-        saveGroceryItems(updatedItems);
+        await persistItems(updatedItems);
     };
 
-    const clearCheckedItems = () => {
+    const clearCheckedItems = async () => {
         if (!window.confirm('Are you sure? (Deleting checked items)')) {
             return;
         }
 
-        const updatedItems = items.filter(item => !item.checked);
-        setItems(updatedItems);
-        saveGroceryItems(updatedItems);
+        const updatedItems = items.filter((item) => !item.checked);
+        await persistItems(updatedItems);
         setVisibleCount(DEFAULT_VISIBLE_ITEMS);
     };
 
@@ -80,13 +87,9 @@ export default function GroceryListWidget() {
         setVisibleCount(DEFAULT_VISIBLE_ITEMS);
     };
 
-
-    const checkedCount = items.filter(item => item.checked).length;
+    const checkedCount = items.filter((item) => item.checked).length;
     const totalCount = items.length;
     const progressPercent = totalCount > 0 ? (checkedCount / totalCount) * 100 : 0;
-
-
-    // show items in expandable groups of 10
     const displayItems = items.slice(0, visibleCount);
     const remainingItems = totalCount - displayItems.length;
     const nextLoadCount = Math.min(DEFAULT_VISIBLE_ITEMS, remainingItems);
@@ -116,11 +119,8 @@ export default function GroceryListWidget() {
                         View Full List
                     </button>
                 </div>
-
             </div>
 
-
-            {/* Progress Bar */}
             {totalCount > 0 && (
                 <div className="mb-6">
                     <div className="flex justify-between text-sm text-muted mb-2">
@@ -137,9 +137,11 @@ export default function GroceryListWidget() {
                 </div>
             )}
 
-
-            {/* Empty State */}
-            {totalCount === 0 && (
+            {isLoading ? (
+                <div className="text-center py-8">
+                    <p className="text-muted">Loading your grocery list...</p>
+                </div>
+            ) : totalCount === 0 ? (
                 <div className="text-center py-8">
                     <p className="text-muted mb-4">Your grocery list is empty.</p>
 
@@ -151,18 +153,13 @@ export default function GroceryListWidget() {
                         Add items
                     </button>
                 </div>
-            )}
-
-
-            {/* Items List */}
-            {totalCount > 0 && (
+            ) : (
                 <div className="space-y-2">
-                    {displayItems.map(item => (
+                    {displayItems.map((item) => (
                         <div
                             key={item.id}
                             className="flex items-center gap-3 py-2 hover:bg-subtle px-2 rounded-lg transition-colors"
                         >
-
                             <input
                                 type="checkbox"
                                 checked={item.checked}
@@ -171,8 +168,7 @@ export default function GroceryListWidget() {
                             />
 
                             <span
-                                className={`flex-1 ${item.checked ? 'line-through text-muted' : 'text-primaryDark'
-                                    }`}
+                                className={`flex-1 ${item.checked ? 'line-through text-muted' : 'text-primaryDark'}`}
                             >
                                 {item.name}
                             </span>

--- a/client/src/context/AuthContext.jsx
+++ b/client/src/context/AuthContext.jsx
@@ -6,7 +6,8 @@ import { AuthContext } from "./useAuth";
 
 export function AuthProvider({ children }) {
   const [user, setUser] = useState(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isAuthLoading, setIsAuthLoading] = useState(true);
+  const [isDataLoading, setIsDataLoading] = useState(true);
 
   useEffect(() => {
     let isMounted = true;
@@ -23,7 +24,7 @@ export function AuthProvider({ children }) {
         }
       } finally {
         if (isMounted) {
-          setIsLoading(false);
+          setIsAuthLoading(false);
         }
       }
     }
@@ -36,16 +37,39 @@ export function AuthProvider({ children }) {
   }, []);
 
   useEffect(() => {
-    if (isLoading) return;
+    if (isAuthLoading) return;
 
-    if (!user) {
-      clearCurrentUserStorageScope();
-      return;
+    let isMounted = true;
+
+    async function bootstrapUserData() {
+      if (!user) {
+        clearCurrentUserStorageScope();
+        if (isMounted) {
+          setIsDataLoading(false);
+        }
+        return;
+      }
+
+      setCurrentUserStorageScope(user);
+
+      try {
+        await ensureStarterRecipesSeeded();
+      } catch (error) {
+        console.error("Failed to seed starter recipes:", error);
+      } finally {
+        if (isMounted) {
+          setIsDataLoading(false);
+        }
+      }
     }
 
-    setCurrentUserStorageScope(user);
-    ensureStarterRecipesSeeded();
-  }, [isLoading, user]);
+    setIsDataLoading(true);
+    bootstrapUserData();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [isAuthLoading, user]);
 
   async function logout() {
     await amplifySignOut();
@@ -57,7 +81,7 @@ export function AuthProvider({ children }) {
       value={{
         user,
         isAuthenticated: Boolean(user),
-        isLoading,
+        isLoading: isAuthLoading || isDataLoading,
         setUser,
         logout,
       }}

--- a/client/src/features/grocery/groceryStorage.js
+++ b/client/src/features/grocery/groceryStorage.js
@@ -1,19 +1,155 @@
-import { getMigratedScopedJson, getScopedStorageKey, setScopedJson } from "../../lib/userStorage";
+import { getDataModel, MODEL_AUTH_OPTIONS } from "../../lib/amplifyDataClient";
 
-const GROCERY_LIST_KEY = "groceryList";
+function getGroceryItemModel() {
+  return getDataModel("GroceryItem");
+}
 
 function ensureArray(value) {
   return Array.isArray(value) ? value : [];
 }
 
-export function getGroceryItems() {
-  return ensureArray(getMigratedScopedJson(GROCERY_LIST_KEY, []));
+function toItemId(item) {
+  if (typeof item?.id === "string" && item.id.trim()) return item.id;
+  if (typeof item?.id === "number") return String(item.id);
+
+  return `grocery-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
-export function saveGroceryItems(items) {
-  setScopedJson(GROCERY_LIST_KEY, ensureArray(items));
+function normalizeLoadedItem(item) {
+  return {
+    id: toItemId(item),
+    name: item.name,
+    quantity: item.quantity ?? "",
+    category: item.category || "Pantry",
+    source: item.source || "Manual",
+    checked: Boolean(item.checked),
+  };
 }
 
-export function getGroceryStorageKey() {
-  return getScopedStorageKey(GROCERY_LIST_KEY);
+function normalizeItemForSave(item) {
+  return {
+    id: toItemId(item),
+    name: item.name,
+    quantity: item.quantity ?? "",
+    category: item.category || "Pantry",
+    source: item.source || "Manual",
+    checked: Boolean(item.checked),
+  };
+}
+
+function sortGroceryItems(items) {
+  return [...items].sort((a, b) => Number(a.checked) - Number(b.checked));
+}
+
+function isValidItem(item) {
+  if (!item || typeof item !== "object") return false;
+  if (typeof item.name !== "string" || !item.name.trim()) return false;
+  return typeof item.id === "string" && item.id.trim().length > 0;
+}
+
+function areItemsEqual(a, b) {
+  return (
+    a.name === b.name &&
+    (a.quantity ?? "") === (b.quantity ?? "") &&
+    (a.category ?? "Pantry") === (b.category ?? "Pantry") &&
+    (a.source ?? "Manual") === (b.source ?? "Manual") &&
+    Boolean(a.checked) === Boolean(b.checked)
+  );
+}
+
+async function executeModelOperation(operationPromise, fallbackMessage) {
+  const result = await operationPromise;
+
+  if (result?.errors?.length) {
+    throw new Error(result.errors[0].message || fallbackMessage);
+  }
+
+  return result?.data ?? null;
+}
+
+export async function getGroceryItems() {
+  const model = getGroceryItemModel();
+  if (!model) return [];
+
+  const { data } = await model.list({
+    ...MODEL_AUTH_OPTIONS,
+    limit: 1000,
+  });
+
+  return sortGroceryItems(ensureArray(data).map(normalizeLoadedItem).filter(isValidItem));
+}
+
+export async function saveGroceryItems(items, previousItems = []) {
+  const model = getGroceryItemModel();
+  if (!model) {
+    throw new Error("Grocery persistence is not ready yet. Sync Amplify outputs first.");
+  }
+
+  const nextItems = sortGroceryItems(
+    ensureArray(items).map(normalizeItemForSave).filter(isValidItem)
+  );
+  const prevItems = sortGroceryItems(
+    ensureArray(previousItems).map(normalizeItemForSave).filter(isValidItem)
+  );
+
+  const nextMap = new Map(nextItems.map((item) => [item.id, item]));
+  const prevMap = new Map(prevItems.map((item) => [item.id, item]));
+  const operations = [];
+
+  for (const [itemId, prevItem] of prevMap.entries()) {
+    if (!nextMap.has(itemId)) {
+      operations.push(
+        executeModelOperation(
+          model.delete({ id: prevItem.id }, MODEL_AUTH_OPTIONS),
+          "Failed to remove grocery item."
+        )
+      );
+    }
+  }
+
+  for (const [itemId, nextItem] of nextMap.entries()) {
+    const prevItem = prevMap.get(itemId);
+
+    if (!prevItem) {
+      operations.push(
+        executeModelOperation(
+          model.create(nextItem, MODEL_AUTH_OPTIONS),
+          "Failed to create grocery item."
+        )
+      );
+      continue;
+    }
+
+    if (!areItemsEqual(prevItem, nextItem)) {
+      operations.push(
+        executeModelOperation(
+          model.update(nextItem, MODEL_AUTH_OPTIONS),
+          "Failed to update grocery item."
+        )
+      );
+    }
+  }
+
+  await Promise.all(operations);
+  return nextItems;
+}
+
+export async function addGroceryItems(itemsToAdd) {
+  const model = getGroceryItemModel();
+  if (!model) {
+    throw new Error("Grocery persistence is not ready yet. Sync Amplify outputs first.");
+  }
+
+  const normalizedItems = ensureArray(itemsToAdd)
+    .map(normalizeItemForSave)
+    .filter(isValidItem);
+
+  for (const item of normalizedItems) {
+    await executeModelOperation(
+      model.create(item, MODEL_AUTH_OPTIONS),
+      "Failed to add grocery item."
+    );
+  }
+
+  return normalizedItems;
 }

--- a/client/src/features/mealPlanner/mealPlannerRepo.js
+++ b/client/src/features/mealPlanner/mealPlannerRepo.js
@@ -47,6 +47,16 @@ function sortEntries(entries) {
   });
 }
 
+async function executeModelOperation(operationPromise, fallbackMessage) {
+  const result = await operationPromise;
+
+  if (result?.errors?.length) {
+    throw new Error(result.errors[0].message || fallbackMessage);
+  }
+
+  return result?.data ?? null;
+}
+
 export async function loadMealPlanEntries() {
   const model = getMealPlanEntryModel();
   if (!model) return [];
@@ -79,7 +89,12 @@ export async function saveMealPlanEntries(entries, previousEntries = []) {
 
   for (const [entryId, prevEntry] of prevMap.entries()) {
     if (!nextMap.has(entryId)) {
-      operations.push(model.delete({ id: prevEntry.id }, MODEL_AUTH_OPTIONS));
+      operations.push(
+        executeModelOperation(
+          model.delete({ id: prevEntry.id }, MODEL_AUTH_OPTIONS),
+          "Failed to remove meal plan entry."
+        )
+      );
     }
   }
 
@@ -87,12 +102,22 @@ export async function saveMealPlanEntries(entries, previousEntries = []) {
     const prevEntry = prevMap.get(entryId);
 
     if (!prevEntry) {
-      operations.push(model.create(nextEntry, MODEL_AUTH_OPTIONS));
+      operations.push(
+        executeModelOperation(
+          model.create(nextEntry, MODEL_AUTH_OPTIONS),
+          "Failed to create meal plan entry."
+        )
+      );
       continue;
     }
 
     if (prevEntry.recipeId !== nextEntry.recipeId) {
-      operations.push(model.update(nextEntry, MODEL_AUTH_OPTIONS));
+      operations.push(
+        executeModelOperation(
+          model.update(nextEntry, MODEL_AUTH_OPTIONS),
+          "Failed to update meal plan entry."
+        )
+      );
     }
   }
 

--- a/client/src/features/mealPlanner/mealPlannerRepo.js
+++ b/client/src/features/mealPlanner/mealPlannerRepo.js
@@ -1,33 +1,100 @@
-// repo for MealPlanner page
-import { getMigratedScopedJson, setScopedJson } from "../../lib/userStorage";
+import { getDataModel, MODEL_AUTH_OPTIONS } from "../../lib/amplifyDataClient";
 
-const STORAGE_KEY = "mealPlanEntries";
+const VALID_SLOTS = ["breakfast", "lunch", "dinner"];
 
-/**
- * MealPlanEntry:
- * {
- *   date: "YYYY-MM-DD",
- *   slot: "breakfast" | "lunch" | "dinner",
- *   dishId: number | string (pool-XXX or manual-XXX)
- * }
- */
-
-function isValidEntry(e) {
-    if (!e || typeof e !== "object") return false;
-    if (typeof e.date !== "string") return false;
-    if (!["breakfast", "lunch", "dinner"].includes(e.slot)) return false;
-    // Accept both numbers (old dish.json IDs) and strings (pool/manual IDs)
-    if (typeof e.dishId !== "number" && typeof e.dishId !== "string") return false;
-    return true;
+function getMealPlanEntryModel() {
+  return getDataModel("MealPlanEntry");
 }
 
-export function loadMealPlanEntries() {
-    const parsed = getMigratedScopedJson(STORAGE_KEY, []);
-    if (!Array.isArray(parsed)) return [];
-    return parsed.filter(isValidEntry);
+function ensureArray(value) {
+  return Array.isArray(value) ? value : [];
 }
 
-export function saveMealPlanEntries(entries) {
-    // assume caller sends an array of valid entries
-    setScopedJson(STORAGE_KEY, entries);
+function toEntryId(date, slot) {
+  return `${date}|${slot}`;
+}
+
+function isValidEntry(entry) {
+  if (!entry || typeof entry !== "object") return false;
+  if (typeof entry.date !== "string") return false;
+  if (!VALID_SLOTS.includes(entry.slot)) return false;
+  if (typeof entry.dishId !== "string" && typeof entry.dishId !== "number") return false;
+  return true;
+}
+
+function normalizeLoadedEntry(entry) {
+  return {
+    id: entry.id,
+    date: entry.date,
+    slot: entry.slot,
+    dishId: entry.recipeId,
+  };
+}
+
+function normalizeEntryForSave(entry) {
+  return {
+    id: entry.id || toEntryId(entry.date, entry.slot),
+    date: entry.date,
+    slot: entry.slot,
+    recipeId: String(entry.dishId),
+  };
+}
+
+function sortEntries(entries) {
+  return [...entries].sort((a, b) => {
+    if (a.date !== b.date) return a.date.localeCompare(b.date);
+    return a.slot.localeCompare(b.slot);
+  });
+}
+
+export async function loadMealPlanEntries() {
+  const model = getMealPlanEntryModel();
+  if (!model) return [];
+
+  const { data } = await model.list({
+    ...MODEL_AUTH_OPTIONS,
+    limit: 1000,
+  });
+
+  return sortEntries(ensureArray(data).map(normalizeLoadedEntry).filter(isValidEntry));
+}
+
+export async function saveMealPlanEntries(entries, previousEntries = []) {
+  const model = getMealPlanEntryModel();
+  if (!model) {
+    throw new Error("Meal planner persistence is not ready yet. Sync Amplify outputs first.");
+  }
+
+  const nextEntries = sortEntries(ensureArray(entries).filter(isValidEntry));
+  const prevEntries = sortEntries(ensureArray(previousEntries).filter(isValidEntry));
+
+  const nextMap = new Map(
+    nextEntries.map((entry) => [toEntryId(entry.date, entry.slot), normalizeEntryForSave(entry)])
+  );
+  const prevMap = new Map(
+    prevEntries.map((entry) => [toEntryId(entry.date, entry.slot), normalizeEntryForSave(entry)])
+  );
+
+  const operations = [];
+
+  for (const [entryId, prevEntry] of prevMap.entries()) {
+    if (!nextMap.has(entryId)) {
+      operations.push(model.delete({ id: prevEntry.id }, MODEL_AUTH_OPTIONS));
+    }
+  }
+
+  for (const [entryId, nextEntry] of nextMap.entries()) {
+    const prevEntry = prevMap.get(entryId);
+
+    if (!prevEntry) {
+      operations.push(model.create(nextEntry, MODEL_AUTH_OPTIONS));
+      continue;
+    }
+
+    if (prevEntry.recipeId !== nextEntry.recipeId) {
+      operations.push(model.update(nextEntry, MODEL_AUTH_OPTIONS));
+    }
+  }
+
+  await Promise.all(operations);
 }

--- a/client/src/features/mealPlanner/useMealPlanner.js
+++ b/client/src/features/mealPlanner/useMealPlanner.js
@@ -1,6 +1,6 @@
 // custom hook for Meal Planner
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { loadMealPlanEntries, saveMealPlanEntries } from "./mealPlannerRepo";
 
 const SLOTS = ["breakfast", "lunch", "dinner"];
@@ -47,7 +47,13 @@ function indexByKey(entries) {
 function arraysEqualJson(a, b) {
     // stable compare by sorting on (date, slot)
     const normalize = (arr) =>
-        [...arr].sort((x, y) => {
+        [...arr]
+            .map((entry) => ({
+                date: entry.date,
+                slot: entry.slot,
+                dishId: entry.dishId,
+            }))
+            .sort((x, y) => {
             if (x.date !== y.date) return x.date.localeCompare(y.date);
             return x.slot.localeCompare(y.slot);
         });
@@ -55,12 +61,11 @@ function arraysEqualJson(a, b) {
 }
 
 export function useMealPlanner() {
-    // load once
-    const initialEntries = useMemo(() => loadMealPlanEntries(), []);
-    const [savedSnapshot, setSavedSnapshot] = useState(initialEntries);
-
-    const [entries, setEntries] = useState(initialEntries);
+    const [savedSnapshot, setSavedSnapshot] = useState([]);
+    const [entries, setEntries] = useState([]);
     const [selectedDate, setSelectedDate] = useState(() => new Date());
+    const [isLoading, setIsLoading] = useState(true);
+    const [isSaving, setIsSaving] = useState(false);
 
     const selectedYmd = useMemo(() => toYmd(selectedDate), [selectedDate]);
 
@@ -86,6 +91,33 @@ export function useMealPlanner() {
         [entries, savedSnapshot]
     );
 
+    useEffect(() => {
+        let isMounted = true;
+
+        async function bootstrapEntries() {
+            try {
+                const loadedEntries = await loadMealPlanEntries();
+
+                if (!isMounted) return;
+
+                setEntries(loadedEntries);
+                setSavedSnapshot(loadedEntries);
+            } catch (error) {
+                console.error("Failed to load meal plan entries:", error);
+            } finally {
+                if (isMounted) {
+                    setIsLoading(false);
+                }
+            }
+        }
+
+        bootstrapEntries();
+
+        return () => {
+            isMounted = false;
+        };
+    }, []);
+
     function getEntry(dateYmd, slot) {
         return entriesMap.get(makeKey(dateYmd, slot)) || null;
     }
@@ -95,7 +127,7 @@ export function useMealPlanner() {
 
         setEntries((prev) => {
             const next = prev.filter((e) => !(e.date === dateYmd && e.slot === slot));
-            next.push({ date: dateYmd, slot, dishId });
+            next.push({ id: makeKey(dateYmd, slot), date: dateYmd, slot, dishId });
             return next;
         });
     }
@@ -106,9 +138,18 @@ export function useMealPlanner() {
         setEntries((prev) => prev.filter((e) => !(e.date === dateYmd && e.slot === slot)));
     }
 
-    function save() {
-        saveMealPlanEntries(entries);
-        setSavedSnapshot(entries);
+    async function save() {
+        setIsSaving(true);
+
+        try {
+            await saveMealPlanEntries(entries, savedSnapshot);
+            setSavedSnapshot(entries);
+        } catch (error) {
+            console.error("Failed to save meal plan entries:", error);
+            alert("We couldn't save your meal plan just yet. Please try again.");
+        } finally {
+            setIsSaving(false);
+        }
     }
 
     function goPrevWeek() {
@@ -126,6 +167,8 @@ export function useMealPlanner() {
         selectedYmd,
         weekDays,
         isDirty,
+        isLoading,
+        isSaving,
 
         // Actions (ViewModel)
         setSelectedDate,

--- a/client/src/features/recipes/recipeStorage.js
+++ b/client/src/features/recipes/recipeStorage.js
@@ -1,8 +1,10 @@
-import { getMigratedScopedJson, setScopedJson } from "../../lib/userStorage";
+import { getDataModel, MODEL_AUTH_OPTIONS } from "../../lib/amplifyDataClient";
 
-const MANUAL_RECIPES_KEY = "manualRecipes";
-const RECIPE_POOL_KEY = "recipePool";
-const STARTER_RECIPES_SEEDED_KEY = "starterRecipesSeeded";
+const RECIPE_SOURCE = {
+  STARTER: "starter",
+  MANUAL: "manual",
+  SPOONACULAR: "spoonacular",
+};
 
 const STARTER_RECIPES = [
   {
@@ -29,6 +31,7 @@ const STARTER_RECIPES = [
       { name: "chia seeds", amount: 1, unit: "tbsp", aisle: "Pantry" },
       { name: "mixed berries", amount: 0.5, unit: "cup", aisle: "Produce" },
     ],
+    source: RECIPE_SOURCE.STARTER,
   },
   {
     id: "starter-eggs-toast",
@@ -53,6 +56,7 @@ const STARTER_RECIPES = [
       { name: "bread", amount: 2, unit: "slices", aisle: "Pantry" },
       { name: "butter", amount: 1, unit: "tsp", aisle: "Dairy" },
     ],
+    source: RECIPE_SOURCE.STARTER,
   },
   {
     id: "starter-greek-yogurt-parfait",
@@ -78,6 +82,7 @@ const STARTER_RECIPES = [
       { name: "strawberries", amount: 0.5, unit: "cup", aisle: "Produce" },
       { name: "honey", amount: 1, unit: "tbsp", aisle: "Pantry" },
     ],
+    source: RECIPE_SOURCE.STARTER,
   },
   {
     id: "starter-turkey-sandwich",
@@ -103,6 +108,7 @@ const STARTER_RECIPES = [
       { name: "lettuce", amount: 2, unit: "leaves", aisle: "Produce" },
       { name: "tomato", amount: 4, unit: "slices", aisle: "Produce" },
     ],
+    source: RECIPE_SOURCE.STARTER,
   },
   {
     id: "starter-chicken-rice-bowl",
@@ -128,6 +134,7 @@ const STARTER_RECIPES = [
       { name: "broccoli", amount: 1, unit: "cup", aisle: "Produce" },
       { name: "soy sauce", amount: 1, unit: "tbsp", aisle: "Pantry" },
     ],
+    source: RECIPE_SOURCE.STARTER,
   },
   {
     id: "starter-caesar-salad",
@@ -153,6 +160,7 @@ const STARTER_RECIPES = [
       { name: "parmesan", amount: 0.25, unit: "cup", aisle: "Dairy" },
       { name: "caesar dressing", amount: 3, unit: "tbsp", aisle: "Pantry" },
     ],
+    source: RECIPE_SOURCE.STARTER,
   },
   {
     id: "starter-veggie-stir-fry",
@@ -178,6 +186,7 @@ const STARTER_RECIPES = [
       { name: "broccoli", amount: 1, unit: "cup", aisle: "Produce" },
       { name: "brown rice", amount: 1, unit: "cup", aisle: "Pasta and Rice" },
     ],
+    source: RECIPE_SOURCE.STARTER,
   },
   {
     id: "starter-pasta-marinara",
@@ -203,6 +212,7 @@ const STARTER_RECIPES = [
       { name: "olive oil", amount: 1, unit: "tbsp", aisle: "Pantry" },
       { name: "garlic", amount: 2, unit: "cloves", aisle: "Produce" },
     ],
+    source: RECIPE_SOURCE.STARTER,
   },
 ];
 
@@ -212,6 +222,56 @@ function cloneStarterRecipes() {
 
 function ensureArray(value) {
   return Array.isArray(value) ? value : [];
+}
+
+function getRecipeModel() {
+  return getDataModel("Recipe");
+}
+
+async function listRecipeRecords() {
+  const model = getRecipeModel();
+  if (!model) return [];
+
+  const { data } = await model.list({
+    ...MODEL_AUTH_OPTIONS,
+    limit: 1000,
+  });
+
+  return ensureArray(data);
+}
+
+function toManualRecipePayload(recipe) {
+  return {
+    id: recipe.id || `manual-${Date.now()}`,
+    title: recipe.title,
+    image: recipe.image,
+    servings: recipe.servings,
+    preparationMinutes: recipe.preparationMinutes,
+    cookingMinutes: recipe.cookingMinutes,
+    nutrition: recipe.nutrition,
+    extendedIngredients: recipe.extendedIngredients,
+    tags: ensureArray(recipe.tags),
+    source: recipe.source || RECIPE_SOURCE.MANUAL,
+  };
+}
+
+export function getPersistedSpoonacularRecipeId(recipeId) {
+  return `spoonacular-${recipeId}`;
+}
+
+function toSpoonacularRecipePayload(recipe) {
+  return {
+    id: getPersistedSpoonacularRecipeId(recipe.id),
+    title: recipe.title,
+    image: recipe.image,
+    servings: recipe.servings ?? 1,
+    preparationMinutes: recipe.preparationMinutes || 0,
+    cookingMinutes: recipe.cookingMinutes || 0,
+    nutrition: recipe.nutrition,
+    extendedIngredients: ensureArray(recipe.extendedIngredients),
+    tags: ensureArray(recipe.tags),
+    source: RECIPE_SOURCE.SPOONACULAR,
+  };
 }
 
 function getNutrientAmount(recipe, nutrientName) {
@@ -250,20 +310,92 @@ function normalizeIngredients(recipe) {
   }));
 }
 
-export function getManualRecipes() {
-  return ensureArray(getMigratedScopedJson(MANUAL_RECIPES_KEY, []));
+export async function listRecipes() {
+  return listRecipeRecords();
 }
 
-export function saveManualRecipes(recipes) {
-  setScopedJson(MANUAL_RECIPES_KEY, ensureArray(recipes));
+export async function getRecipeById(recipeId) {
+  const model = getRecipeModel();
+  if (!model || !recipeId) return null;
+
+  const { data } = await model.get({ id: recipeId }, MODEL_AUTH_OPTIONS);
+  return data ?? null;
 }
 
-export function getRecipePool() {
-  return ensureArray(getMigratedScopedJson(RECIPE_POOL_KEY, []));
+export async function createManualRecipe(recipe) {
+  const model = getRecipeModel();
+  if (!model) {
+    throw new Error("Recipe persistence is not ready yet. Sync Amplify outputs first.");
+  }
+
+  const payload = toManualRecipePayload(recipe);
+  const { data, errors } = await model.create(payload, MODEL_AUTH_OPTIONS);
+
+  if (errors?.length) {
+    throw new Error(errors[0].message || "Failed to create recipe.");
+  }
+
+  return data ?? payload;
 }
 
-export function saveRecipePool(recipes) {
-  setScopedJson(RECIPE_POOL_KEY, ensureArray(recipes));
+export async function updateRecipe(recipe) {
+  const model = getRecipeModel();
+  if (!model) {
+    throw new Error("Recipe persistence is not ready yet. Sync Amplify outputs first.");
+  }
+
+  const payload = toManualRecipePayload(recipe);
+  const { data, errors } = await model.update(payload, MODEL_AUTH_OPTIONS);
+
+  if (errors?.length) {
+    throw new Error(errors[0].message || "Failed to update recipe.");
+  }
+
+  return data ?? payload;
+}
+
+export async function saveSpoonacularRecipe(recipe) {
+  const model = getRecipeModel();
+  if (!model) {
+    throw new Error("Recipe persistence is not ready yet. Sync Amplify outputs first.");
+  }
+
+  const payload = toSpoonacularRecipePayload(recipe);
+  const existingRecipe = await getRecipeById(payload.id);
+
+  if (existingRecipe) {
+    return {
+      recipe: existingRecipe,
+      created: false,
+    };
+  }
+
+  const { data, errors } = await model.create(payload, MODEL_AUTH_OPTIONS);
+
+  if (errors?.length) {
+    throw new Error(errors[0].message || "Failed to save recipe.");
+  }
+
+  return {
+    recipe: data ?? payload,
+    created: true,
+  };
+}
+
+export async function ensureStarterRecipesSeeded() {
+  const model = getRecipeModel();
+  if (!model) return false;
+
+  const existingRecipes = await listRecipeRecords();
+  if (existingRecipes.length > 0) return false;
+
+  const starterRecipes = cloneStarterRecipes();
+
+  await Promise.all(
+    starterRecipes.map((recipe) => model.create(recipe, MODEL_AUTH_OPTIONS))
+  );
+
+  return true;
 }
 
 export function normalizeRecipeForPlanner(recipe) {
@@ -294,59 +426,11 @@ export function normalizeRecipesForPlanner(recipes) {
   return ensureArray(recipes).map(normalizeRecipeForPlanner);
 }
 
-export function isLocalRecipeId(recipeId) {
-  return typeof recipeId === "string" && (recipeId.startsWith("manual-") || recipeId.startsWith("starter-"));
-}
-
-function migrateStarterRecipeImages(recipes) {
-  const starterImageMap = new Map(
-    STARTER_RECIPES.map((recipe) => [recipe.id, recipe.image])
+export function isPersistedRecipeId(recipeId) {
+  return (
+    typeof recipeId === "string" &&
+    (recipeId.startsWith("manual-") ||
+      recipeId.startsWith("starter-") ||
+      recipeId.startsWith("spoonacular-"))
   );
-
-  let changed = false;
-  const nextRecipes = ensureArray(recipes).map((recipe) => {
-    if (!starterImageMap.has(recipe.id)) return recipe;
-
-    const nextImage = starterImageMap.get(recipe.id);
-    const currentImage = recipe?.image;
-    const shouldUpgradeImage =
-      typeof currentImage !== "string" ||
-      !currentImage.trim() ||
-      currentImage.includes("placehold.co");
-
-    if (!shouldUpgradeImage || currentImage === nextImage) {
-      return recipe;
-    }
-
-    changed = true;
-    return {
-      ...recipe,
-      image: nextImage,
-    };
-  });
-
-  return { changed, recipes: nextRecipes };
-}
-
-export function ensureStarterRecipesSeeded() {
-  const migratedManualRecipes = migrateStarterRecipeImages(getManualRecipes());
-  if (migratedManualRecipes.changed) {
-    saveManualRecipes(migratedManualRecipes.recipes);
-  }
-
-  const hasSeeded = Boolean(getMigratedScopedJson(STARTER_RECIPES_SEEDED_KEY, false));
-
-  if (hasSeeded) return false;
-
-  const manualRecipes = migratedManualRecipes.recipes;
-  const recipePool = getRecipePool();
-
-  if (manualRecipes.length > 0 || recipePool.length > 0) {
-    setScopedJson(STARTER_RECIPES_SEEDED_KEY, true);
-    return false;
-  }
-
-  saveManualRecipes(cloneStarterRecipes());
-  setScopedJson(STARTER_RECIPES_SEEDED_KEY, true);
-  return true;
 }

--- a/client/src/features/recipes/recipeStorage.js
+++ b/client/src/features/recipes/recipeStorage.js
@@ -387,13 +387,20 @@ export async function ensureStarterRecipesSeeded() {
   if (!model) return false;
 
   const existingRecipes = await listRecipeRecords();
-  if (existingRecipes.length > 0) return false;
-
-  const starterRecipes = cloneStarterRecipes();
-
-  await Promise.all(
-    starterRecipes.map((recipe) => model.create(recipe, MODEL_AUTH_OPTIONS))
+  const existingRecipeIds = new Set(existingRecipes.map((recipe) => recipe.id));
+  const missingStarterRecipes = cloneStarterRecipes().filter(
+    (recipe) => !existingRecipeIds.has(recipe.id)
   );
+
+  if (missingStarterRecipes.length === 0) return false;
+
+  for (const recipe of missingStarterRecipes) {
+    const { errors } = await model.create(recipe, MODEL_AUTH_OPTIONS);
+
+    if (errors?.length) {
+      throw new Error(errors[0].message || "Failed to seed starter recipes.");
+    }
+  }
 
   return true;
 }

--- a/client/src/lib/amplifyDataClient.js
+++ b/client/src/lib/amplifyDataClient.js
@@ -1,0 +1,21 @@
+import { generateClient } from "aws-amplify/data";
+
+export const MODEL_AUTH_OPTIONS = {
+  authMode: "userPool",
+};
+
+const dataClient = generateClient();
+const warnedModels = new Set();
+
+export function getDataModel(modelName) {
+  const model = dataClient?.models?.[modelName];
+
+  if (!model && !warnedModels.has(modelName)) {
+    console.warn(
+      `Amplify Data model "${modelName}" is unavailable. Sync the backend schema and regenerate amplify_outputs.json.`
+    );
+    warnedModels.add(modelName);
+  }
+
+  return model ?? null;
+}

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -5,7 +5,7 @@ import DashboardCalendar from '../components/DashboardCalendar';
 import GroceryListWidget from '../components/GroceryListWidget';
 import MealCard from '../components/MealCard';
 import { loadMealPlanEntries } from '../features/mealPlanner/mealPlannerRepo';
-import { getManualRecipes, getRecipePool, normalizeRecipesForPlanner } from '../features/recipes/recipeStorage';
+import { listRecipes, normalizeRecipesForPlanner } from '../features/recipes/recipeStorage';
 
 
 export default function Dashboard() {
@@ -13,26 +13,45 @@ export default function Dashboard() {
     const today = dayjs().format('YYYY-MM-DD');
 
 
-    // Load recipes from localStorage
     const [allRecipes, setAllRecipes] = useState([]);
+    const [mealPlanEntries, setMealPlanEntries] = useState([]);
+    const [isLoadingData, setIsLoadingData] = useState(true);
 
 
     useEffect(() => {
-        const loadRecipes = () => {
-            const recipes = normalizeRecipesForPlanner([
-                ...getRecipePool(),
-                ...getManualRecipes(),
-            ]);
-            setAllRecipes(recipes);
+        let isMounted = true;
+
+        async function loadDashboardData() {
+            try {
+                const [recipes, entries] = await Promise.all([
+                    listRecipes(),
+                    loadMealPlanEntries(),
+                ]);
+
+                if (!isMounted) return;
+
+                setAllRecipes(normalizeRecipesForPlanner(recipes));
+                setMealPlanEntries(entries);
+            } catch (error) {
+                console.error('Failed to load dashboard data:', error);
+            } finally {
+                if (isMounted) {
+                    setIsLoadingData(false);
+                }
+            }
+        }
+
+        loadDashboardData();
+
+        return () => {
+            isMounted = false;
         };
-        loadRecipes();
     }, []);
 
 
     // Load today's meals
     const todayMeals = useMemo(() => {
-        const allEntries = loadMealPlanEntries();
-        const todayEntries = allEntries.filter(entry => entry.date === today);
+        const todayEntries = mealPlanEntries.filter(entry => entry.date === today);
 
 
         // Sort by slot (breakfast, lunch, dinner)
@@ -44,7 +63,7 @@ export default function Dashboard() {
         return todayEntries
             .map(entry => allRecipes.find(d => d.id === entry.dishId))
             .filter(Boolean);   // Remove any null/undefined
-    }, [today, allRecipes]);
+    }, [allRecipes, mealPlanEntries, today]);
 
 
     return (
@@ -71,7 +90,11 @@ export default function Dashboard() {
                         Meals for Today
                     </h2>
 
-                    {todayMeals.length === 0 ? (
+                    {isLoadingData ? (
+                        <div className="bg-card rounded-xl shadow-md p-12 text-center text-muted">
+                            Loading today's meals...
+                        </div>
+                    ) : todayMeals.length === 0 ? (
                         // Empty State
                         <div className="bg-card rounded-xl shadow-md p-12 text-center">
 
@@ -119,7 +142,7 @@ export default function Dashboard() {
 
                 {/* Weekly Calendar weekly */}
                 <section>
-                    <DashboardCalendar allRecipes={allRecipes} />
+                    <DashboardCalendar allRecipes={allRecipes} mealPlanEntries={mealPlanEntries} />
                 </section>
 
 

--- a/client/src/pages/GroceryList.jsx
+++ b/client/src/pages/GroceryList.jsx
@@ -1,120 +1,131 @@
-
 import { useEffect, useState } from 'react';
 import { getGroceryItems, saveGroceryItems } from '../features/grocery/groceryStorage';
-
 
 const sortGroceryItems = (items) => {
     return [...items].sort((a, b) => Number(a.checked) - Number(b.checked));
 };
 
-
 function GroceryList() {
     const [searchTerm, setSearchTerm] = useState('');
     const [showAddForm, setShowAddForm] = useState(false);
     const [newItem, setNewItem] = useState({ name: '', quantity: '', category: 'Produce' });
+    const [groceryItems, setGroceryItems] = useState([]);
+    const [isLoading, setIsLoading] = useState(true);
 
-
-    // load items from localStorage and start with empty list
-    const loadGroceryItems = () => {
-        return sortGroceryItems(getGroceryItems());
-    };
-
-
-    const [groceryItems, setGroceryItems] = useState(loadGroceryItems);
-
-    // save to localStorage whenever items change
     useEffect(() => {
-        saveGroceryItems(groceryItems);
-    }, [groceryItems]);
+        let isMounted = true;
 
+        async function loadItems() {
+            try {
+                const items = await getGroceryItems();
+
+                if (isMounted) {
+                    setGroceryItems(sortGroceryItems(items));
+                }
+            } catch (error) {
+                console.error('Failed to load grocery items:', error);
+            } finally {
+                if (isMounted) {
+                    setIsLoading(false);
+                }
+            }
+        }
+
+        loadItems();
+
+        return () => {
+            isMounted = false;
+        };
+    }, []);
 
     const defaultCategories = ['Produce', 'Meat & Poultry', 'Pantry', 'Spices & Seasonings', 'Dairy'];
 
-    const toggleCheck = (id) => {
-        setGroceryItems(items =>
-            sortGroceryItems(items.map(item =>
-                item.id === id ? { ...item, checked: !item.checked } : item
-            ))
-        );
+    const persistItems = async (nextItems) => {
+        const previousItems = groceryItems;
+        setGroceryItems(nextItems);
+
+        try {
+            await saveGroceryItems(nextItems, previousItems);
+        } catch (error) {
+            console.error('Failed to save grocery items:', error);
+            setGroceryItems(previousItems);
+            alert(error.message || 'We could not save your grocery list right now.');
+        }
     };
 
+    const toggleCheck = async (id) => {
+        const nextItems = sortGroceryItems(groceryItems.map((item) =>
+            item.id === id ? { ...item, checked: !item.checked } : item
+        ));
 
-    const removeItem = (id) => {
-        setGroceryItems(items => items.filter(item => item.id !== id));
+        await persistItems(nextItems);
     };
 
+    const removeItem = async (id) => {
+        const nextItems = groceryItems.filter((item) => item.id !== id);
+        await persistItems(nextItems);
+    };
 
-    const clearChecked = () => {
+    const clearChecked = async () => {
         if (!window.confirm('Are you sure? (Deleting checked items)')) {
             return;
         }
 
-        setGroceryItems(items => items.filter(item => !item.checked));
+        const nextItems = groceryItems.filter((item) => !item.checked);
+        await persistItems(nextItems);
     };
 
-    const addNewGroceryItem = () => {
+    const addNewGroceryItem = async () => {
         if (newItem.name.trim() && newItem.quantity.trim()) {
-            const newId = groceryItems.length > 0
-                ? Math.max(...groceryItems.map(i => i.id)) + 1
-                : 1;
-
-            setGroceryItems(sortGroceryItems([...groceryItems, {
-                id: newId,
+            const nextItems = sortGroceryItems([...groceryItems, {
+                id: `grocery-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
                 name: newItem.name,
                 source: 'Manual',
                 quantity: newItem.quantity,
                 category: newItem.category,
                 checked: false
-            }]));
+            }]);
 
+            await persistItems(nextItems);
             setNewItem({ name: '', quantity: '', category: 'Produce' });
             setShowAddForm(false);
         }
     };
 
-    // WILL ADD MORE
     const shareList = () => {
-        // MINT TO DO : implement share functionality (talk with the team--share to what/where)
         alert('Share functionality coming soon!');
     };
 
-    const checkAllInCategory = (category) => {
-        setGroceryItems(items =>
-            sortGroceryItems(items.map(item =>
-                item.category === category ? { ...item, checked: true } : item
-            ))
-        );
+    const checkAllInCategory = async (category) => {
+        const nextItems = sortGroceryItems(groceryItems.map((item) =>
+            item.category === category ? { ...item, checked: true } : item
+        ));
+
+        await persistItems(nextItems);
     };
 
-
-    const filteredItems = groceryItems.filter(item =>
+    const filteredItems = groceryItems.filter((item) =>
         item.name.toLowerCase().includes(searchTerm.toLowerCase())
     );
 
     const categories = Array.from(new Set([
         ...defaultCategories,
         ...filteredItems
-            .map(item => item.category)
+            .map((item) => item.category)
             .filter(Boolean)
     ]));
 
-
     const getItemsByCategory = (category) => {
-        return filteredItems.filter(item => item.category === category);
+        return filteredItems.filter((item) => item.category === category);
     };
 
-
     const totalItems = groceryItems.length;
-    const checkedItems = groceryItems.filter(item => item.checked).length;
+    const checkedItems = groceryItems.filter((item) => item.checked).length;
     const progressPercent = totalItems > 0 ? (checkedItems / totalItems) * 100 : 0;
-
 
     return (
         <div className="min-h-screen bg-[#E8E3D8]">
-            {/* Main Content */}
             <div className="max-w-3xl mx-auto px-4 py-8">
-
-                {/* Header Card */}
                 <div className="bg-white rounded-lg shadow-sm p-6 mb-6">
                     <div className="flex items-center justify-between mb-4">
                         <h1 className="text-2xl font-bold text-gray-800">My Grocery List</h1>
@@ -136,8 +147,6 @@ function GroceryList() {
                         </div>
                     </div>
 
-
-                    {/* Progress Bar */}
                     <div>
                         <div className="flex items-center justify-between mb-2">
                             <span className="text-sm text-gray-600">Shopping progress</span>
@@ -152,8 +161,6 @@ function GroceryList() {
                     </div>
                 </div>
 
-
-                {/* Search Bar */}
                 <div className="bg-white rounded-lg shadow-sm p-4 mb-6">
                     <input
                         type="text"
@@ -164,18 +171,20 @@ function GroceryList() {
                     />
                 </div>
 
-
-                {/* Items List by Category */}
                 <div className="bg-white rounded-lg shadow-sm p-6">
-                    {totalItems === 0 ? (
+                    {isLoading ? (
+                        <div className="text-center py-12 text-gray-500">
+                            Loading your grocery list...
+                        </div>
+                    ) : totalItems === 0 ? (
                         <div className="text-center py-12">
-                            <div className="text-gray-400 text-5xl mb-4">🛒</div>
+                            <div className="text-gray-400 text-5xl mb-4">ðŸ›’</div>
                             <h3 className="text-xl font-semibold text-gray-700 mb-2">Your grocery list is empty</h3>
                             <p className="text-gray-500 mb-6">Add ingredients from recipes or manually add items below</p>
                         </div>
                     ) : (
                         <>
-                            {categories.map(category => {
+                            {categories.map((category) => {
                                 const categoryItems = getItemsByCategory(category);
                                 if (categoryItems.length === 0) return null;
 
@@ -195,7 +204,7 @@ function GroceryList() {
                                         </div>
 
                                         <div className="space-y-2">
-                                            {categoryItems.map(item => (
+                                            {categoryItems.map((item) => (
                                                 <div
                                                     key={item.id}
                                                     className="flex items-center justify-between py-2 group hover:bg-gray-50 rounded px-2 -mx-2 transition-colors"
@@ -221,7 +230,7 @@ function GroceryList() {
                                                             onClick={() => removeItem(item.id)}
                                                             className="text-gray-400 hover:text-red-500 transition-colors opacity-0 group-hover:opacity-100"
                                                         >
-                                                            ✕
+                                                            âœ•
                                                         </button>
                                                     </div>
                                                 </div>
@@ -233,8 +242,6 @@ function GroceryList() {
                         </>
                     )}
 
-
-                    {/* Add New Item Section */}
                     <div className="mt-6 pt-6 border-t border-gray-200">
                         {!showAddForm ? (
                             <button
@@ -266,7 +273,7 @@ function GroceryList() {
                                     onChange={(e) => setNewItem({ ...newItem, category: e.target.value })}
                                     className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-[#6B8E6F]"
                                 >
-                                    {defaultCategories.map(cat => (
+                                    {defaultCategories.map((cat) => (
                                         <option key={cat} value={cat}>{cat}</option>
                                     ))}
                                 </select>
@@ -294,10 +301,8 @@ function GroceryList() {
                 </div>
             </div>
 
-
-            {/* Footer */}
             <footer className="mt-12 pb-8 text-center text-sm text-gray-500">
-                © Nourishly 2025 • <a href="#" className="hover:text-gray-700">Privacy</a> • <a href="#" className="hover:text-gray-700">Terms</a>
+                Â© Nourishly 2025 â€¢ <a href="#" className="hover:text-gray-700">Privacy</a> â€¢ <a href="#" className="hover:text-gray-700">Terms</a>
             </footer>
         </div>
     );

--- a/client/src/pages/GroceryList.jsx
+++ b/client/src/pages/GroceryList.jsx
@@ -46,10 +46,12 @@ function GroceryList() {
 
         try {
             await saveGroceryItems(nextItems, previousItems);
+            return true;
         } catch (error) {
             console.error('Failed to save grocery items:', error);
             setGroceryItems(previousItems);
             alert(error.message || 'We could not save your grocery list right now.');
+            return false;
         }
     };
 
@@ -86,9 +88,12 @@ function GroceryList() {
                 checked: false
             }]);
 
-            await persistItems(nextItems);
-            setNewItem({ name: '', quantity: '', category: 'Produce' });
-            setShowAddForm(false);
+            const didSave = await persistItems(nextItems);
+
+            if (didSave) {
+                setNewItem({ name: '', quantity: '', category: 'Produce' });
+                setShowAddForm(false);
+            }
         }
     };
 
@@ -178,7 +183,7 @@ function GroceryList() {
                         </div>
                     ) : totalItems === 0 ? (
                         <div className="text-center py-12">
-                            <div className="text-gray-400 text-5xl mb-4">ðŸ›’</div>
+                            <div className="text-gray-400 text-5xl mb-4">🛒</div>
                             <h3 className="text-xl font-semibold text-gray-700 mb-2">Your grocery list is empty</h3>
                             <p className="text-gray-500 mb-6">Add ingredients from recipes or manually add items below</p>
                         </div>
@@ -230,7 +235,7 @@ function GroceryList() {
                                                             onClick={() => removeItem(item.id)}
                                                             className="text-gray-400 hover:text-red-500 transition-colors opacity-0 group-hover:opacity-100"
                                                         >
-                                                            âœ•
+                                                            ✕
                                                         </button>
                                                     </div>
                                                 </div>
@@ -302,7 +307,7 @@ function GroceryList() {
             </div>
 
             <footer className="mt-12 pb-8 text-center text-sm text-gray-500">
-                Â© Nourishly 2025 â€¢ <a href="#" className="hover:text-gray-700">Privacy</a> â€¢ <a href="#" className="hover:text-gray-700">Terms</a>
+                © Nourishly 2025 • <a href="#" className="hover:text-gray-700">Privacy</a> • <a href="#" className="hover:text-gray-700">Terms</a>
             </footer>
         </div>
     );

--- a/client/src/pages/MealPlanner.jsx
+++ b/client/src/pages/MealPlanner.jsx
@@ -6,12 +6,18 @@ import { useMealPlanner } from "../features/mealPlanner/useMealPlanner";
 import { listRecipes, normalizeRecipesForPlanner } from "../features/recipes/recipeStorage";
 
 
-function AddMealCard({ label, onClick }) {
+function AddMealCard({ label, onClick, disabled = false }) {
     return (
         <button
             type="button"
             onClick={onClick}
-            className="group flex h-[19.5rem] w-full flex-col items-center justify-center rounded-2xl border border-stone-300 bg-card px-6 py-6 shadow-sm transition duration-200 hover:-translate-y-1 hover:border-primary/40 hover:shadow-lg"
+            disabled={disabled}
+            className={[
+                "group flex h-[19.5rem] w-full flex-col items-center justify-center rounded-2xl border border-stone-300 bg-card px-6 py-6 shadow-sm transition duration-200",
+                disabled
+                    ? "cursor-not-allowed opacity-70"
+                    : "hover:-translate-y-1 hover:border-primary/40 hover:shadow-lg",
+            ].join(" ")}
         >
             <div className="flex h-[4.25rem] w-[4.25rem] items-center justify-center rounded-xl bg-subtle transition duration-200 group-hover:bg-white">
                 <span className="text-4xl font-bold text-muted">+</span>
@@ -198,6 +204,7 @@ export default function MealPlanner() {
 
     const [pickerOpen, setPickerOpen] = useState(false);
     const [pickerSlot, setPickerSlot] = useState(null);
+    const isPlannerBusy = isLoading || isLoadingRecipes;
 
 
     const dishById = useMemo(() => {
@@ -286,6 +293,7 @@ export default function MealPlanner() {
 
 
     function openPicker(slot) {
+        if (isPlannerBusy) return;
         setPickerSlot(slot);
         setPickerOpen(true);
     }
@@ -410,6 +418,7 @@ export default function MealPlanner() {
                                         key={slot}
                                         label={slot[0].toUpperCase() + slot.slice(1)}
                                         onClick={() => openPicker(slot)}
+                                        disabled={isPlannerBusy}
                                     />
                                 );
                             }
@@ -429,7 +438,8 @@ export default function MealPlanner() {
                                             <button
                                                 type="button"
                                                 onClick={() => openPicker(slot)}
-                                                className="text-xs font-semibold text-primary transition hover:text-primaryDark hover:underline"
+                                                disabled={isPlannerBusy}
+                                                className="text-xs font-semibold text-primary transition hover:text-primaryDark hover:underline disabled:cursor-not-allowed disabled:opacity-60"
                                             >
                                                 Replace
                                             </button>
@@ -437,7 +447,8 @@ export default function MealPlanner() {
                                             <button
                                                 type="button"
                                                 onClick={() => removeMeal(selectedYmd, slot)}
-                                                className="text-xs font-semibold text-red-600 transition hover:text-red-700 hover:underline"
+                                                disabled={isPlannerBusy}
+                                                className="text-xs font-semibold text-red-600 transition hover:text-red-700 hover:underline disabled:cursor-not-allowed disabled:opacity-60"
                                             >
                                                 Remove
                                             </button>
@@ -480,13 +491,13 @@ export default function MealPlanner() {
                         <button
                             type="button"
                             onClick={save}
-                            disabled={isSaving || !isDirty}
+                            disabled={isPlannerBusy || isSaving || !isDirty}
                             className={[
                                 "rounded-xl border px-6 py-3.5 text-base font-semibold transition duration-200 hover:-translate-y-0.5 hover:shadow-md",
                                 isDirty
                                     ? "border-primary bg-primary text-white hover:bg-primaryDark"
                                     : "border-primary bg-white text-primary hover:bg-stone-50",
-                                isSaving || !isDirty ? "cursor-default" : "",
+                                isPlannerBusy || isSaving || !isDirty ? "cursor-default" : "",
                             ].join(" ")}
                             style={{ boxShadow: "0 10px 30px rgba(20,30,25,0.08)" }}
                         >

--- a/client/src/pages/MealPlanner.jsx
+++ b/client/src/pages/MealPlanner.jsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useMealPlanner } from "../features/mealPlanner/useMealPlanner";
-import { getManualRecipes, getRecipePool, normalizeRecipesForPlanner } from "../features/recipes/recipeStorage";
+import { listRecipes, normalizeRecipesForPlanner } from "../features/recipes/recipeStorage";
 
 
 function AddMealCard({ label, onClick }) {
@@ -149,22 +149,32 @@ export default function MealPlanner() {
     const navigate = useNavigate();
 
     const [allRecipes, setAllRecipes] = useState([]);
+    const [isLoadingRecipes, setIsLoadingRecipes] = useState(true);
 
     useEffect(() => {
-        const loadRecipes = () => {
-            setAllRecipes(normalizeRecipesForPlanner([
-                ...getRecipePool(),
-                ...getManualRecipes(),
-            ]));
-        };
+        let isMounted = true;
+
+        async function loadRecipes() {
+            try {
+                const persistedRecipes = await listRecipes();
+
+                if (isMounted) {
+                    setAllRecipes(normalizeRecipesForPlanner(persistedRecipes));
+                }
+            } catch (error) {
+                console.error("Failed to load meal planner recipes:", error);
+            } finally {
+                if (isMounted) {
+                    setIsLoadingRecipes(false);
+                }
+            }
+        }
 
         loadRecipes();
 
-        // Reload when window gets focus (when user comes back from adding recipe)
-        const handleFocus = () => loadRecipes();
-        window.addEventListener('focus', handleFocus);
-
-        return () => window.removeEventListener('focus', handleFocus);
+        return () => {
+            isMounted = false;
+        };
     }, []);
 
 
@@ -174,6 +184,8 @@ export default function MealPlanner() {
         selectedYmd,
         weekDays,
         isDirty,
+        isLoading,
+        isSaving,
         goPrevWeek,
         goNextWeek,
         setSelectedDate,
@@ -381,6 +393,12 @@ export default function MealPlanner() {
                         {shortSelectedDate}
                     </p>
 
+                    {(isLoading || isLoadingRecipes) && (
+                        <div className="mt-6 text-center text-sm text-muted">
+                            Loading your meal plan...
+                        </div>
+                    )}
+
                     <div className="mt-8 grid grid-cols-1 gap-4 md:grid-cols-3">
                         {["breakfast", "lunch", "dinner"].map((slot) => {
                             const entry = getEntry(selectedYmd, slot);
@@ -462,15 +480,17 @@ export default function MealPlanner() {
                         <button
                             type="button"
                             onClick={save}
+                            disabled={isSaving || !isDirty}
                             className={[
                                 "rounded-xl border px-6 py-3.5 text-base font-semibold transition duration-200 hover:-translate-y-0.5 hover:shadow-md",
                                 isDirty
                                     ? "border-primary bg-primary text-white hover:bg-primaryDark"
                                     : "border-primary bg-white text-primary hover:bg-stone-50",
+                                isSaving || !isDirty ? "cursor-default" : "",
                             ].join(" ")}
                             style={{ boxShadow: "0 10px 30px rgba(20,30,25,0.08)" }}
                         >
-                            {isDirty ? "Save Plan" : "Saved"}
+                            {isSaving ? "Saving..." : isDirty ? "Save Plan" : "Saved"}
                         </button>
 
                     </div>

--- a/client/src/pages/RecipeDetail.jsx
+++ b/client/src/pages/RecipeDetail.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import AddRecipe from '../components/AddRecipe';
 import { getGroceryItems, saveGroceryItems } from '../features/grocery/groceryStorage';
-import { getManualRecipes, getRecipePool, isLocalRecipeId, saveManualRecipes, saveRecipePool } from '../features/recipes/recipeStorage';
+import { getRecipeById, isPersistedRecipeId, saveSpoonacularRecipe, updateRecipe } from '../features/recipes/recipeStorage';
 
 
 const API_KEY = import.meta.env.VITE_SPOONACULAR_API_KEY;
@@ -52,13 +52,12 @@ export default function RecipeDetail() {
 
     useEffect(() => {
         const fetchRecipeDetail = async () => {
-            if (isLocalRecipeId(id)) {
+            if (isPersistedRecipeId(id)) {
                 try {
-                    const manualRecipes = getManualRecipes();
-                    const recipe = manualRecipes.find(r => r.id === id);
+                    const persistedRecipe = await getRecipeById(id);
 
-                    if (recipe) {
-                        setRecipe(recipe);
+                    if (persistedRecipe) {
+                        setRecipe(persistedRecipe);
                     } else {
                         setError('Recipe not found');
                     }
@@ -133,60 +132,28 @@ export default function RecipeDetail() {
     };
 
 
-    const addToMealPlan = () => {
+    const addToMealPlan = async () => {
         if (!recipe) return;
 
-
-        // Transform Spoonacular recipe
-        const poolRecipe = {
-            id: `pool-${recipe.id}`,
-            name: recipe.title,
-            image: recipe.image,
-            servings: recipe.servings,
-            prep_time: recipe.preparationMinutes || 0,
-            cook_time: recipe.cookingMinutes || 0,
-            meal: 'any',          // Spoonacular doesn't categorize by meal type
-            nutrition: {
-                calories: getNutritionAmount(recipe, 'Calories') ?? 0,
-                protein: getNutritionAmount(recipe, 'Protein') ?? 0,
-                carbs: getNutritionAmount(recipe, 'Carbohydrates') ?? 0,
-                fat: getNutritionAmount(recipe, 'Fat') ?? 0,
-                fiber: getNutritionAmount(recipe, 'Fiber') ?? 0,
-                sodium: getNutritionAmount(recipe, 'Sodium') ?? 0
-            },
-            ingredients: recipe.extendedIngredients.map(ing => ({
-                item: ing.name,
-                amount: `${ing.amount} ${ing.unit}`,
-                category: ing.aisle || 'Pantry'
-            }))
-        };
-
-
-        // Get existing pool from localStorage
-        const existingPool = getRecipePool();
-
-        // Check if already in pool
-        const alreadyExists = existingPool.some(r => r.id === poolRecipe.id);
-
-
-        if (alreadyExists) {
-            alert('This recipe is already in your meal plan pool!');
+        if (isPersistedRecipeId(recipe.id)) {
             navigate('/meal-planner');
             return;
         }
 
-        // Add to pool (cap at 20 recipes max)
-        if (existingPool.length >= 20) {
-            alert('Pool is full (max 20 recipes). Remove a recipe to add more.');
+        try {
+            const { created } = await saveSpoonacularRecipe(recipe);
+
+            if (created) {
+                alert(`Added "${recipe.title}" to your recipes and meal planner!`);
+            } else {
+                alert('This recipe is already available in your meal planner.');
+            }
+
             navigate('/meal-planner');
-            return;
+        } catch (error) {
+            console.error('Failed to save recipe for meal planner:', error);
+            alert(error.message || 'Unable to save this recipe right now.');
         }
-
-        const updatedPool = [...existingPool, poolRecipe];
-        saveRecipePool(updatedPool);
-
-        alert(`Added "${recipe.title}" to your meal plan pool!`);
-        navigate('/meal-planner');
     };
 
 
@@ -213,16 +180,11 @@ export default function RecipeDetail() {
             };
         })
         .filter(Boolean);
-    const isManualRecipe = isLocalRecipeId(recipe?.id);
+    const isManualRecipe = typeof recipe?.id === 'string' && recipe.id.startsWith('manual-');
 
-    const handleSaveManualRecipe = (updatedRecipe) => {
-        const manualRecipes = getManualRecipes();
-        const updatedManualRecipes = manualRecipes.map((manualRecipe) =>
-            manualRecipe.id === updatedRecipe.id ? updatedRecipe : manualRecipe
-        );
-
-        saveManualRecipes(updatedManualRecipes);
-        setRecipe(updatedRecipe);
+    const handleSaveManualRecipe = async (updatedRecipe) => {
+        const savedRecipe = await updateRecipe(updatedRecipe);
+        setRecipe(savedRecipe);
         setIsEditModalOpen(false);
     };
 

--- a/client/src/pages/RecipeDetail.jsx
+++ b/client/src/pages/RecipeDetail.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import AddRecipe from '../components/AddRecipe';
-import { getGroceryItems, saveGroceryItems } from '../features/grocery/groceryStorage';
+import { addGroceryItems } from '../features/grocery/groceryStorage';
 import { getRecipeById, isPersistedRecipeId, saveSpoonacularRecipe, updateRecipe } from '../features/recipes/recipeStorage';
 
 
@@ -107,14 +107,10 @@ export default function RecipeDetail() {
     }, [id]);
 
 
-    const addToGroceryList = () => {
+    const addToGroceryList = async () => {
         if (!recipe) return;
 
-        const existingList = getGroceryItems();
-
-        // Transform Spoonacular ingredients to grocery list format
-        const newItems = recipe.extendedIngredients.map((ingredient, idx) => ({
-            id: Date.now() + Math.random() + idx,
+        const newItems = recipe.extendedIngredients.map((ingredient) => ({
             name: ingredient.name,
             quantity: `${ingredient.amount} ${ingredient.unit}`,
             category: ingredient.aisle || 'Pantry',
@@ -122,13 +118,14 @@ export default function RecipeDetail() {
             checked: false
         }));
 
-
-        const updatedList = [...existingList, ...newItems];
-        saveGroceryItems(updatedList);
-
-
-        alert(`Added all ${recipe.extendedIngredients.length} ingredients to your grocery list!`);
-        navigate('/grocery');
+        try {
+            await addGroceryItems(newItems);
+            alert(`Added all ${recipe.extendedIngredients.length} ingredients to your grocery list!`);
+            navigate('/grocery');
+        } catch (error) {
+            console.error('Failed to add ingredients to grocery list:', error);
+            alert(error.message || 'Unable to add these ingredients right now.');
+        }
     };
 
 

--- a/client/src/pages/Recipes.jsx
+++ b/client/src/pages/Recipes.jsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import AddRecipe from '../components/AddRecipe';
 import RecipeCard from '../components/RecipeCard';
-import { getManualRecipes, saveManualRecipes } from '../features/recipes/recipeStorage';
+import { createManualRecipe, getPersistedSpoonacularRecipeId, listRecipes } from '../features/recipes/recipeStorage';
 
 
 const FILTER_TAGS = ['All', 'Vegetarian', 'Vegan', 'High Protein', 'Low Carb'];
@@ -36,7 +36,7 @@ function recipeMatchesFilter(recipe, activeFilter) {
 
 export default function Recipes() {
     const [recipes, setRecipes] = useState([]);
-    const [manualRecipes, setManualRecipes] = useState([]);
+    const [storedRecipes, setStoredRecipes] = useState([]);
     const [allRecipes, setAllRecipes] = useState([]);           // store full
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState(null);
@@ -46,14 +46,30 @@ export default function Recipes() {
     const [displayCount, setDisplayCount] = useState(RECIPES_PER_PAGE);      // to show
     const [isModalOpen, setIsModalOpen] = useState(false);
 
-
-    // Load manual recipes from localStorage on mount
     useEffect(() => {
-        const loadManualRecipes = () => {
-            setManualRecipes(getManualRecipes());
-        };
+        let isMounted = true;
 
-        loadManualRecipes();
+        async function loadStoredRecipes() {
+            try {
+                const persistedRecipes = await listRecipes();
+
+                if (isMounted) {
+                    setStoredRecipes(persistedRecipes);
+                }
+            } catch (err) {
+                console.error('Failed to load persisted recipes:', err);
+
+                if (isMounted) {
+                    setError('Unable to load your saved recipes right now.');
+                }
+            }
+        }
+
+        loadStoredRecipes();
+
+        return () => {
+            isMounted = false;
+        };
     }, []);
 
 
@@ -71,7 +87,7 @@ export default function Recipes() {
 
     // fetch recipes from Spoonacular API
     const fetchRecipes = useCallback(async () => {
-        const filteredManualRecipes = manualRecipes.filter((recipe) =>
+        const filteredStoredRecipes = storedRecipes.filter((recipe) =>
             recipeMatchesSearch(recipe, searchQuery) &&
             recipeMatchesFilter(recipe, activeFilter)
         );
@@ -79,8 +95,7 @@ export default function Recipes() {
         if (!API_KEY) {
             console.error('Spoonacular API key not configured.');
 
-            // Show manual recipes only if API is not configured
-            const shuffled = shuffleArray(filteredManualRecipes);
+            const shuffled = shuffleArray(filteredStoredRecipes);
             setAllRecipes(shuffled);
             setRecipes(shuffled.slice(0, RECIPES_PER_PAGE));
             setDisplayCount(RECIPES_PER_PAGE);
@@ -133,10 +148,13 @@ export default function Recipes() {
             }
 
             const data = await response.json();
+            const dedupedApiRecipes = data.results.filter(
+                (recipe) => !filteredStoredRecipes.some(
+                    (storedRecipe) => storedRecipe.id === getPersistedSpoonacularRecipeId(recipe.id)
+                )
+            );
 
-
-            // Combine manual recipes + API recipes, then shuffle
-            const combined = [...filteredManualRecipes, ...data.results];
+            const combined = [...filteredStoredRecipes, ...dedupedApiRecipes];
             const shuffled = shuffleArray(combined);
 
 
@@ -147,8 +165,7 @@ export default function Recipes() {
         } catch (err) {
             setError(err.message);
 
-            // error, show manual recipes only
-            const shuffled = shuffleArray(filteredManualRecipes);
+            const shuffled = shuffleArray(filteredStoredRecipes);
             setAllRecipes(shuffled);
             setRecipes(shuffled.slice(0, RECIPES_PER_PAGE));
             setDisplayCount(RECIPES_PER_PAGE);
@@ -156,7 +173,7 @@ export default function Recipes() {
         } finally {
             setLoading(false);
         }
-    }, [activeFilter, manualRecipes, searchQuery]);
+    }, [activeFilter, searchQuery, storedRecipes]);
 
 
     // load and when filter changes or manual recipes change
@@ -201,11 +218,9 @@ export default function Recipes() {
 
 
     // Save manual recipe
-    const handleSaveManualRecipe = (newRecipe) => {
-        const updatedManual = [...manualRecipes, newRecipe];
-
-        setManualRecipes(updatedManual);
-        saveManualRecipes(updatedManual);
+    const handleSaveManualRecipe = async (newRecipe) => {
+        const createdRecipe = await createManualRecipe(newRecipe);
+        setStoredRecipes((prev) => [...prev, createdRecipe]);
     };
 
 


### PR DESCRIPTION
## Summary
Prepares the app for end-to-end persistence by replacing local recipe, meal planner, and grocery storage logic with Amplify-backed data repos. This keeps the current frontend behavior intact while getting the app ready for backend sync and per-user persisted data.

---

## Change Type
feat

---

## Changes
- Replaced recipe storage with an Amplify-backed repo, including starter recipe seeding, manual recipe create/edit, and Spoonacular recipe saving.
- Replaced meal planner storage with Amplify-backed meal slot persistence and improved save error handling.
- Replaced grocery list storage with an Amplify-backed repo and updated the grocery page, dashboard widget, and recipe-detail grocery flow to use it.
- Updated the Amplify data schema to match the current frontend persistence model (`Recipe`, `MealPlanEntry`, and `GroceryItem`).

---

## Testing
- `npm run lint`
- `npm run test:client`
- `npm run build:client`
- Manual testing:
  - verified existing UI flows still render after the persistence-layer swap
  - verified grocery add form only closes after a successful save attempt
  - verified recipe, meal planner, and grocery flows fail gracefully when Amplify models are unavailable
  - confirmed the app is still blocked on backend sync / `amplify_outputs.json` regeneration for true end-to-end persistence testing

---

## Pre-Merge Checklist
- [x] Builds and runs locally
- [x] Branch name follows repo convention
- [x] PR title follows repo convention
- [x] ESLint passes
