### PR TITLE
fix: scope persisted recipe and meal plan ids per user

### DIFF
--- a/client/src/features/mealPlanner/mealPlannerRepo.js
+++ b/client/src/features/mealPlanner/mealPlannerRepo.js
@@ -1,3 +1,4 @@
+import { getCurrentUser } from "aws-amplify/auth";
 import { getDataModel, MODEL_AUTH_OPTIONS } from "../../lib/amplifyDataClient";
 
 const VALID_SLOTS = ["breakfast", "lunch", "dinner"];
@@ -10,8 +11,27 @@ function ensureArray(value) {
   return Array.isArray(value) ? value : [];
 }
 
-function toEntryId(date, slot) {
+function sanitizeIdSegment(value) {
+  return String(value || "user").replace(/[^a-zA-Z0-9-]/g, "-");
+}
+
+async function getCurrentOwnerKey() {
+  try {
+    const currentUser = await getCurrentUser();
+    return sanitizeIdSegment(
+      currentUser?.userId || currentUser?.username || currentUser?.signInDetails?.loginId
+    );
+  } catch {
+    return "user";
+  }
+}
+
+function toEntryKey(date, slot) {
   return `${date}|${slot}`;
+}
+
+function toScopedEntryId(ownerKey, date, slot) {
+  return `meal-plan-${ownerKey}-${date}-${slot}`;
 }
 
 function isValidEntry(entry) {
@@ -31,9 +51,9 @@ function normalizeLoadedEntry(entry) {
   };
 }
 
-function normalizeEntryForSave(entry) {
+function normalizeEntryForSave(entry, ownerKey) {
   return {
-    id: entry.id || toEntryId(entry.date, entry.slot),
+    id: toScopedEntryId(ownerKey, entry.date, entry.slot),
     date: entry.date,
     slot: entry.slot,
     recipeId: String(entry.dishId),
@@ -77,12 +97,19 @@ export async function saveMealPlanEntries(entries, previousEntries = []) {
 
   const nextEntries = sortEntries(ensureArray(entries).filter(isValidEntry));
   const prevEntries = sortEntries(ensureArray(previousEntries).filter(isValidEntry));
+  const ownerKey = await getCurrentOwnerKey();
 
   const nextMap = new Map(
-    nextEntries.map((entry) => [toEntryId(entry.date, entry.slot), normalizeEntryForSave(entry)])
+    nextEntries.map((entry) => [
+      toEntryKey(entry.date, entry.slot),
+      normalizeEntryForSave(entry, ownerKey),
+    ])
   );
   const prevMap = new Map(
-    prevEntries.map((entry) => [toEntryId(entry.date, entry.slot), normalizeEntryForSave(entry)])
+    prevEntries.map((entry) => [
+      toEntryKey(entry.date, entry.slot),
+      normalizeEntryForSave(entry, ownerKey),
+    ])
   );
 
   const operations = [];

--- a/client/src/features/recipes/recipeStorage.js
+++ b/client/src/features/recipes/recipeStorage.js
@@ -1,3 +1,4 @@
+import { getCurrentUser } from "aws-amplify/auth";
 import { getDataModel, MODEL_AUTH_OPTIONS } from "../../lib/amplifyDataClient";
 
 const RECIPE_SOURCE = {
@@ -224,6 +225,63 @@ function ensureArray(value) {
   return Array.isArray(value) ? value : [];
 }
 
+function sanitizeIdSegment(value) {
+  return String(value || "user").replace(/[^a-zA-Z0-9-]/g, "-");
+}
+
+async function getCurrentOwnerKey() {
+  try {
+    const currentUser = await getCurrentUser();
+    return sanitizeIdSegment(
+      currentUser?.userId || currentUser?.username || currentUser?.signInDetails?.loginId
+    );
+  } catch {
+    return "user";
+  }
+}
+
+function buildStarterRecipeId(templateId, ownerKey) {
+  const suffix = String(templateId).startsWith("starter-")
+    ? String(templateId).slice("starter-".length)
+    : String(templateId);
+
+  return `starter-${ownerKey}-${suffix}`;
+}
+
+function buildScopedSpoonacularRecipeId(recipeId, ownerKey) {
+  return `spoonacular-${ownerKey}-${recipeId}`;
+}
+
+function serializeJsonField(value) {
+  if (value == null) return null;
+  return JSON.stringify(value);
+}
+
+function parseJsonField(value, fallback) {
+  if (value == null || value === "") return fallback;
+
+  if (typeof value === "string") {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return fallback;
+    }
+  }
+
+  return value;
+}
+
+function normalizeRecipeRecord(recipe) {
+  if (!recipe) return null;
+
+  return {
+    ...recipe,
+    nutrition: parseJsonField(recipe.nutrition, { nutrients: [] }),
+    extendedIngredients: parseJsonField(recipe.extendedIngredients, []),
+    tags: ensureArray(recipe.tags),
+  };
+}
+
 function getRecipeModel() {
   return getDataModel("Recipe");
 }
@@ -237,7 +295,7 @@ async function listRecipeRecords() {
     limit: 1000,
   });
 
-  return ensureArray(data);
+  return ensureArray(data).map(normalizeRecipeRecord).filter(Boolean);
 }
 
 function toManualRecipePayload(recipe) {
@@ -248,8 +306,8 @@ function toManualRecipePayload(recipe) {
     servings: recipe.servings,
     preparationMinutes: recipe.preparationMinutes,
     cookingMinutes: recipe.cookingMinutes,
-    nutrition: recipe.nutrition,
-    extendedIngredients: recipe.extendedIngredients,
+    nutrition: serializeJsonField(recipe.nutrition),
+    extendedIngredients: serializeJsonField(recipe.extendedIngredients),
     tags: ensureArray(recipe.tags),
     source: recipe.source || RECIPE_SOURCE.MANUAL,
   };
@@ -259,16 +317,30 @@ export function getPersistedSpoonacularRecipeId(recipeId) {
   return `spoonacular-${recipeId}`;
 }
 
-function toSpoonacularRecipePayload(recipe) {
+function isLegacyOrScopedStarterRecipeId(recipeId, templateId, ownerKey) {
+  return recipeId === templateId || recipeId === buildStarterRecipeId(templateId, ownerKey);
+}
+
+export function isPersistedSpoonacularRecipeMatch(recipe, spoonacularRecipeId) {
+  const recipeId = typeof recipe?.id === "string" ? recipe.id : "";
+  const legacyId = getPersistedSpoonacularRecipeId(spoonacularRecipeId);
+
+  return (
+    recipe?.source === RECIPE_SOURCE.SPOONACULAR &&
+    (recipeId === legacyId || recipeId.endsWith(`-${spoonacularRecipeId}`))
+  );
+}
+
+function toSpoonacularRecipePayload(recipe, ownerKey) {
   return {
-    id: getPersistedSpoonacularRecipeId(recipe.id),
+    id: buildScopedSpoonacularRecipeId(recipe.id, ownerKey),
     title: recipe.title,
     image: recipe.image,
     servings: recipe.servings ?? 1,
     preparationMinutes: recipe.preparationMinutes || 0,
     cookingMinutes: recipe.cookingMinutes || 0,
-    nutrition: recipe.nutrition,
-    extendedIngredients: ensureArray(recipe.extendedIngredients),
+    nutrition: serializeJsonField(recipe.nutrition),
+    extendedIngredients: serializeJsonField(ensureArray(recipe.extendedIngredients)),
     tags: ensureArray(recipe.tags),
     source: RECIPE_SOURCE.SPOONACULAR,
   };
@@ -319,7 +391,7 @@ export async function getRecipeById(recipeId) {
   if (!model || !recipeId) return null;
 
   const { data } = await model.get({ id: recipeId }, MODEL_AUTH_OPTIONS);
-  return data ?? null;
+  return normalizeRecipeRecord(data);
 }
 
 export async function createManualRecipe(recipe) {
@@ -335,7 +407,7 @@ export async function createManualRecipe(recipe) {
     throw new Error(errors[0].message || "Failed to create recipe.");
   }
 
-  return data ?? payload;
+  return normalizeRecipeRecord(data ?? payload);
 }
 
 export async function updateRecipe(recipe) {
@@ -351,7 +423,7 @@ export async function updateRecipe(recipe) {
     throw new Error(errors[0].message || "Failed to update recipe.");
   }
 
-  return data ?? payload;
+  return normalizeRecipeRecord(data ?? payload);
 }
 
 export async function saveSpoonacularRecipe(recipe) {
@@ -360,8 +432,13 @@ export async function saveSpoonacularRecipe(recipe) {
     throw new Error("Recipe persistence is not ready yet. Sync Amplify outputs first.");
   }
 
-  const payload = toSpoonacularRecipePayload(recipe);
-  const existingRecipe = await getRecipeById(payload.id);
+  const ownerKey = await getCurrentOwnerKey();
+  const payload = toSpoonacularRecipePayload(recipe, ownerKey);
+  const existingRecipe =
+    (await getRecipeById(payload.id)) ||
+    (await listRecipeRecords()).find((storedRecipe) =>
+      isPersistedSpoonacularRecipeMatch(storedRecipe, recipe.id)
+    );
 
   if (existingRecipe) {
     return {
@@ -377,7 +454,7 @@ export async function saveSpoonacularRecipe(recipe) {
   }
 
   return {
-    recipe: data ?? payload,
+    recipe: normalizeRecipeRecord(data ?? payload),
     created: true,
   };
 }
@@ -386,16 +463,28 @@ export async function ensureStarterRecipesSeeded() {
   const model = getRecipeModel();
   if (!model) return false;
 
+  const ownerKey = await getCurrentOwnerKey();
   const existingRecipes = await listRecipeRecords();
   const existingRecipeIds = new Set(existingRecipes.map((recipe) => recipe.id));
   const missingStarterRecipes = cloneStarterRecipes().filter(
-    (recipe) => !existingRecipeIds.has(recipe.id)
+    (recipe) =>
+      ![...existingRecipeIds].some((recipeId) =>
+        isLegacyOrScopedStarterRecipeId(recipeId, recipe.id, ownerKey)
+      )
   );
 
   if (missingStarterRecipes.length === 0) return false;
 
   for (const recipe of missingStarterRecipes) {
-    const { errors } = await model.create(recipe, MODEL_AUTH_OPTIONS);
+    const { errors } = await model.create(
+      {
+        ...recipe,
+        id: buildStarterRecipeId(recipe.id, ownerKey),
+        nutrition: serializeJsonField(recipe.nutrition),
+        extendedIngredients: serializeJsonField(recipe.extendedIngredients),
+      },
+      MODEL_AUTH_OPTIONS
+    );
 
     if (errors?.length) {
       throw new Error(errors[0].message || "Failed to seed starter recipes.");

--- a/client/src/pages/Recipes.jsx
+++ b/client/src/pages/Recipes.jsx
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useState } from 'react';
 import AddRecipe from '../components/AddRecipe';
 import RecipeCard from '../components/RecipeCard';
-import { createManualRecipe, getPersistedSpoonacularRecipeId, listRecipes } from '../features/recipes/recipeStorage';
+import {
+    createManualRecipe,
+    isPersistedSpoonacularRecipeMatch,
+    listRecipes,
+} from '../features/recipes/recipeStorage';
 
 
 const FILTER_TAGS = ['All', 'Vegetarian', 'Vegan', 'High Protein', 'Low Carb'];
@@ -9,6 +13,7 @@ const RECIPES_PER_PAGE = 6;
 const MAX_RECIPES = 18;     // LOCK at 18 cards max
 const API_KEY = import.meta.env.VITE_SPOONACULAR_API_KEY;
 const API_BASE = 'https://api.spoonacular.com/recipes';
+let hasWarnedMissingSpoonacularKey = false;
 
 function normalizeRecipeTags(recipe) {
     if (!Array.isArray(recipe?.tags)) return [];
@@ -93,7 +98,10 @@ export default function Recipes() {
         );
 
         if (!API_KEY) {
-            console.error('Spoonacular API key not configured.');
+            if (!hasWarnedMissingSpoonacularKey) {
+                console.warn('Spoonacular API key not configured.');
+                hasWarnedMissingSpoonacularKey = true;
+            }
 
             const shuffled = shuffleArray(filteredStoredRecipes);
             setAllRecipes(shuffled);
@@ -150,7 +158,7 @@ export default function Recipes() {
             const data = await response.json();
             const dedupedApiRecipes = data.results.filter(
                 (recipe) => !filteredStoredRecipes.some(
-                    (storedRecipe) => storedRecipe.id === getPersistedSpoonacularRecipeId(recipe.id)
+                    (storedRecipe) => isPersistedSpoonacularRecipeMatch(storedRecipe, recipe.id)
                 )
             );
 


### PR DESCRIPTION
## Summary
Fixes the follow-up persistence issues that showed up once the real Amplify backend was connected, so recipe seeding/saving and meal planner persistence now work correctly per user. This keeps the current frontend behavior the same while making the backend-backed flows actually usable.

---

## Change Type
fix

---

## Changes
- Fixed recipe persistence payload handling by serializing/parsing JSON fields for Amplify-backed `Recipe` records.
- Scoped starter recipe and persisted Spoonacular recipe IDs per user to avoid cross-account record collisions.
- Scoped meal planner entry IDs per user so meal plan saves no longer conflict across accounts.
- Reduced repeated Spoonacular missing-key console spam to a single warning.

---

## Testing
- `npm run lint`
- `npm run test:client`
- `npm run build:client`
- Manual testing:
  - verified starter recipes seed successfully after connecting the updated Amplify backend
  - verified manual recipe creation persists after refresh
  - verified grocery list persistence still works after refresh
  - verified meal planner save path no longer uses the old global entry ID format

---

## Pre-Merge Checklist
- [x] Builds and runs locally
- [x] Branch name follows repo convention
- [x] PR title follows repo convention
- [x] ESLint passes
